### PR TITLE
Add CODEOWNERS, rename to tcort etc.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Owner @tcort
+# Supported by @smainil @BaseMax @WillGibson
+* @tcort @smainil @BaseMax @WillGibson

--- a/.github/FUNDING.yml 
+++ b/.github/FUNDING.yml 
@@ -1,1 +1,0 @@
-ko_fi: gauravnelson

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ### GitHub Action - Markdown link check 🔗✔️
-[![GitHub Marketplace](https://img.shields.io/badge/GitHub%20Marketplace-Markdown%20link%20check-brightgreen?style=for-the-badge)](https://github.com/marketplace/actions/markdown-link-check)
+[![GitHub Marketplace](https://img.shields.io/badge/GitHub%20Marketplace-Markdown%20link%20check-brightgreen?style=for-the-badge)](https://github.com/marketplace/actions/markdown-link-check-action)
+
+Forked from [gaurav-nelson/github-action-markdown-link-check](https://github.com/gaurav-nelson/github-action-markdown-link-check), which is no longer maintained.
 
 This GitHub action checks all Markdown files in your repository for broken links. (Uses [tcort/markdown-link-check](https://github.com/tcort/markdown-link-check))
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,5 @@
-<table>
-  <tr>
-    <td>
-      <h1> ⛔️ Deprecation notice (Apr 2025) </h1>
-      <p>
-        This repository is now ⛔️ <strong>deprecated</strong> and is no longer actively maintained.
-      </p>
-      <p>
-        For support and further development, please use the maintained fork available at
-        <a href="https://github.com/tcort/github-action-markdown-link-check">Tcort GitHub Action Markdown Link Check</a>.
-      </p>
-      <hr />
-      <p>
-        I have also developed a new tool called
-        <a href="https://github.com/UmbrellaDocs/linkspector">Linkspector</a>,
-        which offers improved functionality and reduced false positives.
-        You can try this tool as an alternative if it fits your needs.
-      </p>
-      <p>
-        Try <a href="https://github.com/UmbrellaDocs/action-linkspector">GitHub Action Linkspector</a>!
-      </p>
-      <hr />
-    </td>
-  </tr>
-</table>
-
 ### GitHub Action - Markdown link check 🔗✔️
 [![GitHub Marketplace](https://img.shields.io/badge/GitHub%20Marketplace-Markdown%20link%20check-brightgreen?style=for-the-badge)](https://github.com/marketplace/actions/markdown-link-check)
-<a href="https://liberapay.com/gaurav-nelson/donate"><img alt="Donate using Liberapay" src="https://liberapay.com/assets/widgets/donate.svg"></a>
 
 This GitHub action checks all Markdown files in your repository for broken links. (Uses [tcort/markdown-link-check](https://github.com/tcort/markdown-link-check))
 
@@ -44,7 +17,7 @@ This GitHub action checks all Markdown files in your repository for broken links
        runs-on: ubuntu-latest
        steps:
        - uses: actions/checkout@master
-       - uses: gaurav-nelson/github-action-markdown-link-check@v1
+       - uses: tcort/github-action-markdown-link-check@v1
    ```
 
 ### Real-life usage samples
@@ -59,8 +32,6 @@ Markdown link check.
    ![](https://img.shields.io/github/stars/tendermint/tendermint?style=social)
 1. [pyroscope-io/pyroscope](https://github.com/pyroscope-io/pyroscope/blob/main/.github/workflows/lint-markdown.yml)
    ![](https://img.shields.io/github/stars/pyroscope-io/pyroscope?style=social)
-
-If you are using this on production, consider [buying me a coffee](https://liberapay.com/gaurav-nelson/) ☕.
 
 ## Configuration
 
@@ -99,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: tcort/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'
@@ -132,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: tcort/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'
@@ -180,7 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: tcort/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'
@@ -198,7 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: tcort/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
         folder-path: 'md/dir1, md/dir2'
@@ -251,7 +222,7 @@ jobs:
 
     # Checks the status of hyperlinks in .md files in verbose mode
     - name: Check links
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: tcort/github-action-markdown-link-check@v1
       with:
         use-verbose-mode: 'yes'
 ```
@@ -267,22 +238,15 @@ On running the workflow described above, the output shown below is obtained
 ## Versioning
 GitHub Action - Markdown link check follows the [GitHub recommended versioning strategy](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md).
 
-1. To use a specific released version of the action ([Releases](https://github.com/gaurav-nelson/github-action-markdown-link-check/releases)):
+1. To use a specific released version of the action ([Releases](https://github.com/tcort/github-action-markdown-link-check/releases)):
    ```yml
-   - uses: gaurav-nelson/github-action-markdown-link-check@1.0.1
+   - uses: tcort/github-action-markdown-link-check@1
    ```
 1. To use a major version of the action:
    ```yml
-   - uses: gaurav-nelson/github-action-markdown-link-check@v1
+   - uses: tcort/github-action-markdown-link-check@v1
    ```
-1. You can also specify a [specific commit SHA](https://github.com/gaurav-nelson/github-action-markdown-link-check/commits/master) as an action version:
+1. You can also specify a [specific commit SHA](https://github.com/tcort/github-action-markdown-link-check/commits/master) as an action version:
    ```yml
-   - uses: gaurav-nelson/github-action-markdown-link-check@44a942b2f7ed0dc101d556f281e906fb79f1f478
+   - uses: tcort/github-action-markdown-link-check@44a942b2f7ed0dc101d556f281e906fb79f1f478
    ```
-
-<hr>
-<p align="center">
- <a name="coffee" href="https://liberapay.com/gaurav-nelson/">
-  <img src="https://i.imgur.com/1Q1YoHz.gif" alt="Buy me a coffee.">
- </a>
-</p>

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'markdown-link-check'
+name: 'markdown-link-check-action'
 description: 'Check if all links are valid in markdown files.'
 author: 'Maintainers of tcort/markdown-link-check'
 branding:

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'markdown-link-check'
 description: 'Check if all links are valid in markdown files.'
-author: 'Gaurav Nelson'
+author: 'Maintainers of tcort/markdown-link-check'
 branding:
   icon: 'link'  
   color: 'green'


### PR DESCRIPTION
Addresses https://github.com/tcort/markdown-link-check/issues/439.

Intention is to release this essentially unchanged version, then we can look at porting over any issues from the forked repository, starting with https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/204